### PR TITLE
fix: Order.Fee numeric INSERT (22P02) blocking order creation

### DIFF
--- a/modules/products/service.go
+++ b/modules/products/service.go
@@ -162,6 +162,10 @@ func (p *productsService) CreateOrders(userId string, ordersData []DataRequest) 
 				ProductID: orderData.ProductID,
 				BuyerID:   uuid.FromStringOrNil(userId),
 				Quantity:  orderData.Quantity,
+				// Fee maps to a numeric column; the zero value "" is invalid numeric
+				// input (SQLSTATE 22P02). Seed a valid placeholder — the observer
+				// records the real platform fee from the on-chain payout event.
+				Fee: "0",
 			}
 			order.CreatedAt = orderData.CreatedAt
 


### PR DESCRIPTION
Order creation 500'd (`invalid input syntax for type numeric: ""`, SQLSTATE 22P02): `Order.Fee` is a string field on a numeric column, so the zero value `""` failed every INSERT. Seed a valid `"0"` placeholder at creation; the observer records the real on-chain fee later.

Surfaced by the full-stack e2e once the frontend seller-session + checkout bugs were fixed (paired frontend PR). With this, all 11 e2e specs pass on a fresh stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)